### PR TITLE
Listen on IPv4 by default

### DIFF
--- a/api/config.json
+++ b/api/config.json
@@ -1,6 +1,7 @@
 {
     "api": {
       "port": 2251,
+      "ipv6Only": false,
       "base_url": "/api"
     },
     "panel": {

--- a/api/index.ts
+++ b/api/index.ts
@@ -33,7 +33,7 @@ if (cluster.isWorker) {
 
   httpHandler(app);
 
-  server = app.listen(config.api.port, () => {});
+  server = app.listen(config.api.port, config.api.ipv6Only ? "::" : "0.0.0.0", () => {});
 } else {
   // autoUpdate().then(() => {
   var workers = [];

--- a/node/index.js
+++ b/node/index.js
@@ -1,6 +1,8 @@
 const express = require("express");
 const app = express();
 const port = 12645;
+const ipv6Only = false;
+
 app.use(express.json());
 
 const dockerStatistics = require("./docker");
@@ -109,4 +111,4 @@ app.post("/qemu/vm/create", async (req, res) => {
   console.log(`qemu/vm/create`);
 });
 
-app.listen(port, () => {});
+app.listen(port, ipv6Only ? "::" : "0.0.0.0", () => {});


### PR DESCRIPTION
By default, without a parameter for the host it reverts to IPv6 and depending on operating system, possibly IPv4 listening. Does not listen on IPv4 on Debian or Ubuntu 20.04 in my experience. 

https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback
